### PR TITLE
feat: push generation of ics to separate branch

### DIFF
--- a/.github/workflows/run-and-commit.yml
+++ b/.github/workflows/run-and-commit.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin calendar-updates || git checkout -b calendar-updates
+          git checkout calendar-updates
           git add ical/filtered_calendar.ics
           git commit -m "Update filtered_calendar.ics [skip ci]" || echo "No changes to commit"
-          git push origin main
+          git push origin calendar-updates

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ blocklist:
 The filtered calendar will be saved as `filtered_calendar.ics` in the `ical` directory. Use the Github raw URL of that file and add it to your calendar.
 Use this URL and adjust it to your forked repo:
 
-`https://raw.githubusercontent.com/<gh-username>/uniCal/main/ical/filtered_calendar.ics`
+`https://raw.githubusercontent.com/<gh-username>/uniCal/calendar-updates/ical/filtered_calendar.ics`
 
 ## Keeping your Calendar Up-To-Date
 


### PR DESCRIPTION
Regarding #2  these few lines push the generated ics file to a separate branch `calendar-update`.

- Principle of SoC: development changes stay on main, while technical updates (calendar artifacts) live in their own branch.
- Url of ics file has been updated (see changes in readme).

@matteokosina might consider to protect branch `calendar-update`, so that only the technical user `github-actions[bot]` can push directly.